### PR TITLE
Implement next|prev as commands to sent/receive

### DIFF
--- a/include/calfenster/app_server.h
+++ b/include/calfenster/app_server.h
@@ -1,21 +1,30 @@
 #pragma once
 
+#include <qglobal.h>
 #include <qobject.h>
 
 #include <QLocalServer>
-
-// #include "app_server.moc"
+#include <optional>
 
 namespace calfenster {
 class AppServer : public QObject {
   Q_OBJECT
 
  public:
+  enum class Command : quint8 {
+    kShutdown = 1,
+    kPrevMonth,
+    kNextMonth,
+    kCommandSize  // keep as last for sanity check
+  };
+
   explicit AppServer(QObject* parent = nullptr);
   virtual ~AppServer() = default;
 
   [[nodiscard]] bool HasOtherInstance() const { return other_instance_; }
-  bool SendShutdownRequest();
+  bool SendCommand(Command cmd);
+
+  static std::optional<Command> CommandFromString(const QString& command);
 
  protected:
   QLocalServer* server_ = nullptr;
@@ -24,5 +33,9 @@ class AppServer : public QObject {
  public slots:
   void SlotNewConnection();
   void SlotReadClient();
+
+ signals:
+  void ShowPrevMonth();
+  void ShowNextMonth();
 };
 }  // namespace calfenster

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,12 @@
 #include <qboxlayout.h>
 #include <qcalendarwidget.h>
 #include <qcommandlineparser.h>
+#include <qglobal.h>
 #include <qobject.h>
 #include <qwidget.h>
 
 #include <cstdlib>
-#include <iostream>
+#include <optional>
 
 #include "calfenster/app_server.h"
 #include "calfenster/configuration.h"
@@ -18,15 +19,34 @@ int main(int argc, char* argv[]) {
 
   // Command line parsing
   QCommandLineParser command_line;
+  command_line.addPositionalArgument(
+      "command", "prev | next: Show previous or next month");
   command_line.setApplicationDescription("A simple calender widget.");
   command_line.addHelpOption();
   // actual parsing of the command line
   command_line.process(app);
 
+  // check the given commands
+  const QStringList commands = command_line.positionalArguments();
+  if (commands.size() > 1) {
+    qCritical() << "Got more than 1 command: " << commands;
+    command_line.showHelp(EXIT_FAILURE);
+  }
+  const std::optional<calfenster::AppServer::Command> command =
+      commands.isEmpty() ? calfenster::AppServer::Command::kShutdown
+                         : calfenster::AppServer::CommandFromString(
+                               commands[0].trimmed().toLower());
+
   calfenster::AppServer app_server;
   if (app_server.HasOtherInstance()) {
-    std::cout << "Other instance found, try to terminate" << std::endl;
-    bool request_status = app_server.SendShutdownRequest();
+    if (!command.has_value()) {
+      qWarning() << "Wrong command supplied";
+      command_line.showHelp(EXIT_FAILURE);
+    }
+    if (command.value() == calfenster::AppServer::Command::kShutdown) {
+      qInfo() << "Other instance found, try to terminate";
+    }
+    const bool request_status = app_server.SendCommand(command.value());
     return request_status ? EXIT_SUCCESS : EXIT_FAILURE;
   }
 
@@ -35,7 +55,11 @@ int main(int argc, char* argv[]) {
   auto* stack_layout = new QHBoxLayout(&main_widget);
   stack_layout->addWidget(calendar_widget);
 
-  calfenster::Configuration config;
+  // Connect signals from AppServer to CalendarWidget
+  QObject::connect(&app_server, SIGNAL(ShowPrevMonth()), calendar_widget,
+                   SLOT(showPreviousMonth()));
+  QObject::connect(&app_server, SIGNAL(ShowNextMonth()), calendar_widget,
+                   SLOT(showNextMonth()));
 
   auto* event_filter = new calfenster::EventFilter(&main_widget);
   event_filter->main_widget = &main_widget;
@@ -43,6 +67,7 @@ int main(int argc, char* argv[]) {
   main_widget.installEventFilter(event_filter);
   calendar_widget->installEventFilter(event_filter);
 
+  calfenster::Configuration config;
   config.ConfigureWindow(main_widget);
   config.ConfigureCalendar(*calendar_widget);
 


### PR DESCRIPTION
Implement commands which are on startup send to the other instance. Currently we support:
- next: Advance the displayed month to the next month
- prev: Same as next but switch to previous month